### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/oota-sushikuitee/roulette/security/code-scanning/4](https://github.com/oota-sushikuitee/roulette/security/code-scanning/4)

To fix this issue, add an explicit `permissions` block to the workflow to restrict the GITHUB_TOKEN's scopes to only what this job requires. Since the workflow only installs dependencies and runs tests, it does not require write access to any repository resource. The minimal and recommended permission settings for this workflow are `contents: read`. To apply this to the entire workflow, place the `permissions` block at the top level, just below the `name:` key and above the `on:` key in `.github/workflows/test.yml`. No additional imports or external dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
